### PR TITLE
Reverted site-logo call in favor of theme prefix route

### DIFF
--- a/components/site-logo/site-logo.php
+++ b/components/site-logo/site-logo.php
@@ -1,1 +1,1 @@
-<?php if ( function_exists( jetpack_the_site_logo ) ) jetpack_the_site_logo(); ?>
+<?php component_s_the_site_logo(); ?>


### PR DESCRIPTION
This was done originally but updated to fix an undefined fn error in the generator.
Decided on an alternative route for the fix in the generator.