### PR TITLE
Add variables for button background colour on hover and focus.

### DIFF
--- a/assets/stylesheets/shared/_forms.scss
+++ b/assets/stylesheets/shared/_forms.scss
@@ -14,12 +14,14 @@ input[type="submit"] {
 	text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
 
 	&:hover {
+		background: $color__background-button-hover;
 		border-color: $color__border-button-hover;
 		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.8), inset 0 15px 17px rgba(255, 255, 255, 0.8), inset 0 -5px 12px rgba(0, 0, 0, 0.02);
 	}
 
 	&:active,
 	&:focus {
+		background: $color__background-button-focus;
 		border-color: $color__border-button-focus;
 		box-shadow: inset 0 -1px 0 rgba(255, 255, 255, 0.5), inset 0 2px 5px rgba(0, 0, 0, 0.15);
 	}

--- a/assets/stylesheets/variables/_colors.scss
+++ b/assets/stylesheets/variables/_colors.scss
@@ -17,8 +17,8 @@ $color__text-input-focus: $color__black;
 $color__text-screen: $color__primary;
 
 $color__background-button: $color__white;
-$color__background-button: $color__light-grey;
-$color__background-button-hover: $color__mid-grey;
+$color__background-button-hover: $color__light-grey;
+$color__background-button-focus: $color__mid-grey;
 
 $color__link: $color__light-black;
 $color__link-visited: $color__light-black;


### PR DESCRIPTION
I was setting my button styles and realised the colour variables were a bit misleading: the `$color__background-button` variable was declared twice, and there was a value for `$color__background-button-hover` but none for :focus. Neither the hover nor the focus background colour were used.

To prevent confusion and to allow for more straightforward customisation, I'd suggest using the mid-grey as a background colour for both hover and focus states. This feels like a pretty sane default, and it's easy for the user to override if they want a different colour, or no colour at all.