### PR TITLE
Copyedit contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,32 @@
 # Contributing
 
-Hey there, thanks for wanting to contribute the Theme Pattern Library - you rock!
+Hey there! Thanks for wanting to contribute the Theme Pattern Library—you rock!
 
 ## Creating an issue
 
-If you find a bug or would like something added to the library, then creating an issue is a great starting place. Here is a good process for creating an issue:
-1. **Search** first to ensure this hasn't already been reported.
-2. **Create** an issue. If a bug, ensure someone can recreate it. A video works really well to show people. If an enhancement then a mockup, showing example or sketch helps.
-3. **PR** what is even better than an issue is an issue with a PR already attached. If you have found a bug and can fix it, then attach a PR to your issue.
+If you find a bug or would like something added to the library, create a new issue! To create a new issue:
 
+1. **Search** existing issues first to ensure your issue hasn't already been reported.
+2. **Create** the issue. If it's a bug, provide steps to recreate the issue. (Attaching a video or screenshot is a great way to visually show what you're seeing. If your issue is an enhancement, attach a mockup or sketch to explain your idea.
+3. **Pull Request** If you have found a bug and can fix it, attach a pull request to your issue! See below for more details on submitting PRs.
 
 ## Feature requests
 
-Feature requests are welcome. But take a moment to find out whether your idea
-fits with the scope and aims of the project. It's up to *you* to make a strong
-case to convince the project's developers of the merits of this feature. Please
-provide as much detail and context as possible.
-
+Feature requests are welcome. Think about whether your idea
+fits with the [scope and aims of the project](https://github.com/Automattic/theme-pattern-library/wiki/History).
+It's up to *you* to make a strong case to convince the project's
+developers of the merits of this feature. Please provide as much
+detail and context as possible.
 
 ## Pull requests
 
-Good pull requests - patches, improvements, new features - are a fantastic
-help. They should remain focused in scope and avoid containing unrelated
+Good pull requests—patches, improvements, new features—are a great
+help. They should remain focused in scope and shouldn't contain unrelated
 commits.
 
-Please adhere to the coding conventions used throughout a project (indentation,
-accurate comments, etc.) and any other requirements (such as test coverage).
+Please adhere to the coding conventions used throughout the project with 
+regard to indentation, accurate comments, etc. The pattern library follows
+the [WordPress coding conventions](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
 
 Follow this process if you'd like your work considered for inclusion in the
 project:
@@ -35,11 +36,11 @@ project:
 
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone https://github.com/<your-username>/slush-slush-theme-pattern-library
+   git clone https://github.com/<your-username>/theme-pattern-library
    # Navigate to the newly cloned directory
-   cd slush-slush-theme-pattern-library
+   cd theme-pattern-library
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/danielrobert/slush-slush-theme-pattern-library
+   git remote add upstream https://github.com/Automattic/theme-pattern-library
    ```
 
 2. If you cloned a while ago, get the latest changes from upstream:
@@ -49,7 +50,7 @@ project:
    git pull upstream <dev-branch>
    ```
 
-3. Create a new topic branch (off the main project development branch) to
+3. Create a new feature branch (off the main project development branch) to
    contain your feature, change, or fix:
 
    ```bash
@@ -60,7 +61,7 @@ project:
    message guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
    or your code is unlikely be merged into the main project. Use Git's
    [interactive rebase](https://help.github.com/articles/interactive-rebase)
-   feature to tidy up your commits before making them public.
+   feature to tidy up your commits, if necessary, before making them public.
 
 5. Locally merge (or rebase) the upstream development branch into your topic branch:
 
@@ -68,7 +69,7 @@ project:
    git pull [--rebase] upstream <dev-branch>
    ```
 
-6. Push your topic branch up to your fork:
+6. Push your feature branch up to your fork:
 
    ```bash
    git push origin <topic-branch-name>
@@ -127,11 +128,7 @@ Removing features on repo
 git commit -m "Remove Feature: nameoffeature Message about this"
 ```
 
-Ignoring Travis CI build on repo
-
-```bash
-git commit -m "Commit message here [ci-skip]"
-```
-
 **IMPORTANT**: By submitting a patch, you agree to allow the project owner to
 license your work under the same license as that used by the project.
+
+Thanks for helping make the theme pattern library better!


### PR DESCRIPTION
I noticed these could use a little love. Mostly, I've massaged for better readability, but I've also removed references to irrelevant stuff (test coverage we don't have), corrected incorrect repo paths, and provided additional context where helpful (coding standards, aims of project, etc).

I wasn't sure about the "Conventions of commit messages" section—it feels a bit heavy-handed, and it's sort of prescriptive about commit scenarios you may never make. (I have never submitted a commit that's "Update x, x, x". I actually think that might be a poor commit message—update with regards to what?) I'd instead like to rewrite into something a little more helpful, along the lines of https://github.com/erlang/otp/wiki/Writing-good-commit-messages or http://chris.beams.io/posts/git-commit/ ... but short enough for contributors to easily grok. A five-point list would be a good start, for example. 

Thoughts?