### PR TITLE
Fixing double underscore in component_s_site_logo_init function reference

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -39,7 +39,7 @@ function component_s_site_logo_init() {
 	add_image_size( 'component-s-logo', 200, 200 );
 	add_theme_support( 'site-logo', array( 'size' => 'component-s-logo' ) );
 }
-add_action( 'after_setup_theme', 'component_s__site_logo_init' );
+add_action( 'after_setup_theme', 'component_s_site_logo_init' );
 
 /**
  * Return early if Site Logo is not available.

--- a/types/business/inc/jetpack.php
+++ b/types/business/inc/jetpack.php
@@ -43,7 +43,7 @@ function component_s_site_logo_init() {
 	add_image_size( 'component-s-logo', 200, 200 );
 	add_theme_support( 'site-logo', array( 'size' => 'component-s-logo' ) );
 }
-add_action( 'after_setup_theme', 'component_s__site_logo_init' );
+add_action( 'after_setup_theme', 'component_s_site_logo_init' );
 
 /**
  * Return early if Site Logo is not available.

--- a/types/portfolio/inc/jetpack.php
+++ b/types/portfolio/inc/jetpack.php
@@ -45,7 +45,7 @@ function component_s_site_logo_init() {
 	add_image_size( 'component-s-logo', 200, 200 );
 	add_theme_support( 'site-logo', array( 'size' => 'component-s-logo' ) );
 }
-add_action( 'after_setup_theme', 'component_s__site_logo_init' );
+add_action( 'after_setup_theme', 'component_s_site_logo_init' );
 
 /**
  * Return early if Site Logo is not available.


### PR DESCRIPTION
Double underscore in component_s_site_logo_init was causing warnings on theme activation for business and portfolio themes.

Reported here: https://github.com/Automattic/components.underscores.me/issues/44