### PR TITLE
Remove custom header admin callbacks.

### DIFF
--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -18,8 +18,6 @@
  * Set up the WordPress core custom header feature.
  *
  * @uses component_s_header_style()
- * @uses component_s_admin_header_style()
- * @uses component_s_admin_header_image()
  */
 function component_s_custom_header_setup() {
 	add_theme_support( 'custom-header', apply_filters( 'component_s_custom_header_args', array(
@@ -29,8 +27,6 @@ function component_s_custom_header_setup() {
 		'height'                 => 250,
 		'flex-height'            => true,
 		'wp-head-callback'       => 'component_s_header_style',
-		'admin-head-callback'    => 'component_s_admin_header_style',
-		'admin-preview-callback' => 'component_s_admin_header_image',
 	) ) );
 }
 add_action( 'after_setup_theme', 'component_s_custom_header_setup' );
@@ -75,52 +71,3 @@ function component_s_header_style() {
 	<?php
 }
 endif; // component_s_header_style
-
-if ( ! function_exists( 'component_s_admin_header_style' ) ) :
-/**
- * Styles the header image displayed on the Appearance > Header admin panel.
- *
- * @see component_s_custom_header_setup().
- */
-function component_s_admin_header_style() {
-?>
-	<style type="text/css">
-		.appearance_page_custom-header #headimg {
-			border: none;
-		}
-		#headimg h1,
-		#desc {
-		}
-		#headimg h1 {
-		}
-		#headimg h1 a {
-		}
-		#desc {
-		}
-		#headimg img {
-		}
-	</style>
-<?php
-}
-endif; // component_s_admin_header_style
-
-if ( ! function_exists( 'component_s_admin_header_image' ) ) :
-/**
- * Custom header image markup displayed on the Appearance > Header admin panel.
- *
- * @see component_s_custom_header_setup().
- */
-function component_s_admin_header_image() {
-?>
-	<div id="headimg">
-		<h1 class="displaying-header-text">
-			<a id="name" style="<?php echo esc_attr( 'color: #' . get_header_textcolor() ); ?>" onclick="return false;" href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php bloginfo( 'name' ); ?></a>
-		</h1>
-		<div class="displaying-header-text" id="desc" style="<?php echo esc_attr( 'color: #' . get_header_textcolor() ); ?>"><?php bloginfo( 'description' ); ?></div>
-		<?php if ( get_header_image() ) : ?>
-		<img src="<?php header_image(); ?>" alt="">
-		<?php endif; ?>
-	</div>
-<?php
-}
-endif; // component_s_admin_header_image


### PR DESCRIPTION
These haven't been needed since 4.1, when the Header page under Appearance was deprecated.
That "Header" link now links directly to the Customizer. Themes don't need to use these outdated callbacks anymore, so let's remove the extra code.

Related: https://github.com/Automattic/_s/pull/879
