### PR TITLE
Ensure max-width is respected by clearfix mixin.

### DIFF
--- a/assets/stylesheets/shared/_mixins.scss
+++ b/assets/stylesheets/shared/_mixins.scss
@@ -15,6 +15,7 @@
 @mixin clearfix() {
 	content: "";
 	display: table;
+	table-layout: fixed;
 }
 
 // Clear after (not all clearfix need this also)

--- a/style.css
+++ b/style.css
@@ -641,6 +641,7 @@ a:hover, a:active {
 .site-footer:after {
   content: "";
   display: table;
+  table-layout: fixed;
 }
 
 .clear:after,


### PR DESCRIPTION
In certain cases, when using `display: table` for a clearfix, some browsers will ignore the `max-width: 100%` property set on child elements of the clearfixed elements, leading to elements inside getting all spilly. Adding `table-layout: fixed` here solves the issue with any negative ramifications.

This fix was something I struggled with for Pique, but it's easy once you find the problem!