### PR TITLE
Magazine: Use consistent theme slug prefix.

### DIFF
--- a/types/magazine/inc/jetpack.php
+++ b/types/magazine/inc/jetpack.php
@@ -12,44 +12,44 @@
  *
  * @since theme-magazine 1.0
  */
-function theme_traditional_jetpack_setup() {
+function component_s_jetpack_setup() {
 	add_theme_support( 'infinite-scroll', array(
 		'container' => 'main',
-		'render'    => 'theme_traditional_infinite_scroll_render',
+		'render'    => 'component_s_infinite_scroll_render',
 		'footer'    => 'page',
 	) );
-} // end function theme_traditional_jetpack_setup
-add_action( 'after_setup_theme', 'theme_traditional_jetpack_setup' );
+} // end function component_s_jetpack_setup
+add_action( 'after_setup_theme', 'component_s_jetpack_setup' );
 
 /**
  * Custom render function for Infinite Scroll.
  *
  * @since theme-magazine 1.0
  */
-function theme_traditional_infinite_scroll_render() {
+function component_s_infinite_scroll_render() {
 	while ( have_posts() ) {
 		the_post();
 		get_template_part( 'template-parts/content', get_post_format() );
 	}
-} // end function theme_traditional_infinite_scroll_render
+} // end function component_s_infinite_scroll_render
 
 /**
  * Add support for the Site Logo
  *
  * @since theme-magazine 1.0
  */
-function theme_traditional_site_logo_init() {
+function component_s_site_logo_init() {
 	add_image_size( 'theme-magazine-logo', 200, 200 );
 	add_theme_support( 'site-logo', array( 'size' => 'theme-magazine-logo' ) );
 }
-add_action( 'after_setup_theme', 'theme_traditional_site_logo_init' );
+add_action( 'after_setup_theme', 'component_s_site_logo_init' );
 
 /**
  * Return early if Site Logo is not available.
  *
  * @since theme-magazine 1.0
  */
-function theme_traditional_the_site_logo() {
+function component_s_the_site_logo() {
 	if ( ! function_exists( 'jetpack_the_site_logo' ) ) {
 		return;
 	} else {


### PR DESCRIPTION
All other types are using `component_s` as their theme-slug prefix, so it makes sense to retain consistency here. 

Fixes #96.

