### PR TITLE
Removing 'not' from if statement checking for sidebar widget

### DIFF
--- a/sidebar.php
+++ b/sidebar.php
@@ -5,7 +5,7 @@
  * @package component_s
  */
 
-if ( ! is_active_sidebar( 'sidebar-1' ) ) : ?>
+if ( is_active_sidebar( 'sidebar-1' ) ) : ?>
 	<div id="secondary" class="widget-area" role="complementary">
 		<?php dynamic_sidebar( 'sidebar-1' ); ?>
 	</div><!-- #secondary -->


### PR DESCRIPTION
Right now sidebar widgets won't be written to the page, and this change will fix that. 