### PR TITLE
Add skeleton content for hero component.

### DIFF
--- a/components/content-hero/content-hero.php
+++ b/components/content-hero/content-hero.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * The template used for displaying hero content.
+ *
+ * @package Components
+ */
+?>
+
+<?php if ( has_post_thumbnail() ) : ?>
+	<div class="components-hero">
+		<?php the_post_thumbnail( 'components-hero' ); ?>
+	</div><!-- .hero -->
+<?php endif; ?>


### PR DESCRIPTION
Fixes #132.

I looked at some of our themes that use this component (Edin, Sela, Publication, Pique, Canape) and they all do slightly different things, so I figured it would make most sense to just use the barest code shared by all—that is, the large featured image. 

Quite a few of those themes used the featured image as a background image, instead of a regular image, but this could be confusing without CSS unless we follow Canape's model of using both a background image and an inline image. For our purposes, I think simpler is better.

Everything else (page title is most likely/popular, but some of the themes above also showed breadcrumbs & categories), a user could add themselves—they aren't consistent across all themes that use this convention.